### PR TITLE
Check for null pushNotification

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationPublisher.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationPublisher.java
@@ -17,8 +17,10 @@ public class PushNotificationPublisher extends BroadcastReceiver {
         Application applicationContext = (Application) context.getApplicationContext();
         final IPushNotification pushNotification = PushNotification.get(applicationContext, intent.getExtras());
 
-        Log.i("PN_TAG", "PushNotificationPublisher: Prepare To Publish: " + id + ", Now Time: " + currentTime);
+        if (pushNotification != null) {
+            Log.i("PN_TAG", "PushNotificationPublisher: Prepare To Publish: " + id + ", Now Time: " + currentTime);
 
-        pushNotification.sendNotificationScheduled(id);
+            pushNotification.sendNotificationScheduled(id);
+        }
     }
 }


### PR DESCRIPTION
This is a fix for [MM-14830](https://mattermost.atlassian.net/browse/MM-14830). [pushNotification](https://github.com/mattermost/react-native-notifications/blob/master/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationPublisher.java#L18) can be null if [verifyNotificationBundle(bundle)](https://github.com/mattermost/react-native-notifications/blob/master/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java#L50) is false, so let's check for null prior to calling [sendNotificationScheduled](https://github.com/mattermost/react-native-notifications/blob/master/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationPublisher.java#L22)